### PR TITLE
Resolution improvement of Baro data

### DIFF
--- a/boards/cats_rev1Pro/Core/Src/config/globals.c
+++ b/boards/cats_rev1Pro/Core/Src/config/globals.c
@@ -53,7 +53,7 @@ MS5607 MS1 = {
     .cs_port = CS_BARO1_GPIO_Port,
     .cs_pin = CS_BARO1_Pin,
     .spi_bus = &SPI_BARO1,
-    .osr = MS5607_OSR_256,
+    .osr = MS5607_OSR_2048,
 };
 
 SPI_BUS SPI_BARO2 = {
@@ -63,7 +63,7 @@ MS5607 MS2 = {
     .cs_port = CS_BARO2_GPIO_Port,
     .cs_pin = CS_BARO2_Pin,
     .spi_bus = &SPI_BARO2,
-    .osr = MS5607_OSR_256,
+    .osr = MS5607_OSR_2048,
 };
 
 SPI_BUS SPI_BARO3 = {
@@ -73,7 +73,7 @@ MS5607 MS3 = {
     .cs_port = CS_BARO3_GPIO_Port,
     .cs_pin = CS_BARO3_Pin,
     .spi_bus = &SPI_BARO3,
-    .osr = MS5607_OSR_256,
+    .osr = MS5607_OSR_2048,
 };
 
 SPI_BUS SPI_MAG = {

--- a/boards/cats_rev1Pro/Core/Src/sensors/ms5607.c
+++ b/boards/cats_rev1Pro/Core/Src/sensors/ms5607.c
@@ -89,7 +89,9 @@ static void ms_read_bytes(MS5607 *dev, uint8_t command, uint8_t *pData, uint16_t
 }
 
 // Write command
-static void ms_write_command(MS5607 *dev, uint8_t command) { spi_transmit(dev->spi_bus, &command, 1); }
+static void ms_write_command(MS5607 *dev, uint8_t command) {
+	spi_transmit(dev->spi_bus, &command, 1);
+}
 
 static void read_calibration(MS5607 *dev) {
   for (int i = 0; i < 6; i++) {

--- a/boards/cats_rev1Pro/Core/Src/tasks/task_baro_read.c
+++ b/boards/cats_rev1Pro/Core/Src/tasks/task_baro_read.c
@@ -49,7 +49,7 @@ void task_baro_read(void *argument) {
     read_baro();
 
     // Prepare new readout
-    if(stage == READ_BARO_TEMPERATURE){
+    if (stage == READ_BARO_TEMPERATURE) {
     	prepare_pres();
     	stage = READ_BARO_PRESSURE;
     } else {


### PR DESCRIPTION
OSR of MS5607 sensor is now set to `2048` from `256`.

![osr](https://user-images.githubusercontent.com/47953330/127670352-bb0b8028-ed69-4617-8341-1ccd49b6b70e.png)

In OSR 2048 two readouts can be done each state estimation step (one for the pressure and one for the temperature).
The baro read task is now running at 200Hz and sampling the pressure then the temperature one after the other.

The improvements can be easily seen from the logs.

Before, around +- 0.8m noise:
![osr_256](https://user-images.githubusercontent.com/47953330/127670604-0e57fba6-bc8f-41f5-923a-3d3b4ed2dee3.png)

After, around +- 0.3m noise:
![osr_2048](https://user-images.githubusercontent.com/47953330/127670630-11dbdcce-572e-4c20-b221-757cb3363817.png)

