### PR TITLE
Added Machtimer.

### DIFF
--- a/boards/cats_rev1Pro/src/cli/settings.c
+++ b/boards/cats_rev1Pro/src/cli/settings.c
@@ -52,6 +52,8 @@ const clivalue_t valueTable[] = {
      &global_cats_config.config.control_settings.main_altitude},
     {"acc_threshhold", VAR_UINT16, .config.minmaxUnsigned = {1500, 8000},
      &global_cats_config.config.control_settings.liftoff_acc_threshold},
+    {"mach_timer_duration", VAR_UINT16, .config.minmaxUnsigned = {0, 60000},
+            &global_cats_config.config.control_settings.mach_timer_duration},
 
     // Timers
     {"timer1_start", VAR_UINT8 | MODE_LOOKUP, .config.lookup = {TABLE_EVENTS},

--- a/boards/cats_rev1Pro/src/config/globals.c
+++ b/boards/cats_rev1Pro/src/config/globals.c
@@ -141,6 +141,7 @@ dt_telemetry_trigger_t dt_telemetry_trigger = {0};
 
 /** Timers **/
 cats_timer_t ev_timers[NUM_TIMERS] = {};
+cats_timer_t mach_timer = {};
 
 /** Recorder Queue **/
 osMessageQueueId_t rec_queue;

--- a/boards/cats_rev1Pro/src/config/globals.h
+++ b/boards/cats_rev1Pro/src/config/globals.h
@@ -83,6 +83,7 @@ extern dt_telemetry_trigger_t dt_telemetry_trigger;
 
 /** Timers **/
 extern cats_timer_t ev_timers[NUM_TIMERS];
+extern cats_timer_t mach_timer;
 
 /** Recorder Queue **/
 extern osMessageQueueId_t rec_queue;

--- a/boards/cats_rev1Pro/src/control/flight_phases.c
+++ b/boards/cats_rev1Pro/src/control/flight_phases.c
@@ -160,7 +160,6 @@ static void check_idle_phase(flight_fsm_t *fsm_state, imu_data_t *imu_data, cont
   if (fsm_state->memory[1] > TIME_THRESHOLD_IDLE_TO_MOV) {
     trigger_event(EV_MOVING);
     fsm_state->flight_state = MOVING;
-    fsm_state->state_changed = 1;
     fsm_state->clock_memory = 0;
     fsm_state->memory[1] = 0;
     fsm_state->memory[2] = 0;
@@ -238,6 +237,11 @@ static void check_thrusting_1_phase(flight_fsm_t *fsm_state, estimation_output_t
 }
 
 static void check_coasting_phase(flight_fsm_t *fsm_state, estimation_output_t *state_data) {
+
+    if(osTimerIsRunning(mach_timer.timer_id)){
+        return;
+    }
+
   if (state_data->velocity < 0) {
     fsm_state->memory[1]++;
   }

--- a/boards/cats_rev1Pro/src/tasks/task_flight_fsm.c
+++ b/boards/cats_rev1Pro/src/tasks/task_flight_fsm.c
@@ -70,7 +70,6 @@ _Noreturn void task_flight_fsm(__attribute__((unused)) void *argument) {
       if (max_a < global_kf_data.acceleration) max_a = global_kf_data.acceleration;
       if (max_h < global_kf_data.height) max_h = global_kf_data.height;
     }
-
     if (global_flight_state.state_changed == 1) {
       log_error("State Changed FlightFSM to %s", flight_fsm_map[global_flight_state.flight_state]);
       flight_state_t flight_state = {.ts = osKernelGetTickCount(),

--- a/boards/cats_rev1Pro/src/tasks/task_init.c
+++ b/boards/cats_rev1Pro/src/tasks/task_init.c
@@ -374,8 +374,15 @@ static void init_timers() {
     }
   }
 
+  /* Init mach Timer */
+  mach_timer.timer_init_event = EV_LIFTOFF;
+  mach_timer.execute_event = EV_MACHTIMER;
+  mach_timer.timer_duration_ticks = global_cats_config.config.control_settings.mach_timer_duration;
+
   /* Create Timers */
   for (uint32_t i = 0; i < used_timers; i++) {
     ev_timers[i].timer_id = osTimerNew((void *)trigger_event, osTimerOnce, (void *)ev_timers[i].execute_event, NULL);
   }
+  /* Create mach timer */
+  mach_timer.timer_id = osTimerNew((void *)trigger_event, osTimerOnce, (void *)mach_timer.execute_event, NULL);
 }

--- a/boards/cats_rev1Pro/src/tasks/task_peripherals.c
+++ b/boards/cats_rev1Pro/src/tasks/task_peripherals.c
@@ -47,6 +47,12 @@ _Noreturn void task_peripherals(__attribute__((unused)) void* argument) {
           osTimerStart(ev_timers[i].timer_id, ev_timers[i].timer_duration_ticks);
         }
       }
+      /* start Mach timer if needed */
+      if(curr_event == mach_timer.timer_init_event){
+          if(mach_timer.timer_duration_ticks > 0) {
+              osTimerStart(mach_timer.timer_id, mach_timer.timer_duration_ticks);
+          }
+      }
       peripheral_act_t* action_list = event_action_map[curr_event].action_list;
       for (uint32_t i = 0; i < event_action_map[curr_event].num_actions; ++i) {
         timestamp_t curr_ts = osKernelGetTickCount();

--- a/boards/cats_rev1Pro/src/util/types.h
+++ b/boards/cats_rev1Pro/src/util/types.h
@@ -210,6 +210,7 @@ typedef struct {
 
 typedef struct {
   uint16_t liftoff_acc_threshold;
+  uint16_t mach_timer_duration;
   uint16_t main_altitude;
 } control_settings_t;
 
@@ -258,6 +259,7 @@ typedef enum {
   EV_TOUCHDOWN,
   EV_CUSTOM_1,
   EV_CUSTOM_2,
+  EV_MACHTIMER,
   EV_HEHE = 0xFFFFFFFF /* TODO <- optimize these enums and remove this guy */
 } cats_event_e;
 


### PR DESCRIPTION
Machtimer can be set over the CLI. Fixed the recording bug of the raw_acc data.

The Machtimer is enabled when EV_LIFTOFF is called. Then it runs and once it is done it throws the Event EV_MACHTIMER for logging purposes and potential use later on.
The flight_fsm task checks if the timer is running while the flight_fsm is in the coasting phase. If the timer is running, the flight_fsm is not allowed to go to the apogee state.

Closes #30 