### PR TITLE
Add a flyable default config.

### DIFF
--- a/boards/cats_rev1Pro/src/cli/cli_commands.c
+++ b/boards/cats_rev1Pro/src/cli/cli_commands.c
@@ -354,8 +354,12 @@ static void cli_cmd_config(const char *cmd_name, char *args) {
 }
 
 static void cli_cmd_defaults(const char *cmd_name, char *args) {
-  cc_defaults();
-  cli_print_line("Reset to default values");
+  bool use_default_outputs = true;
+  if (!strcmp(args, "--no-outputs")) {
+    use_default_outputs = false;
+  }
+  cc_defaults(use_default_outputs);
+  cli_print_linef("Reset to default values%s", use_default_outputs ? "": " [no outputs]");
 }
 
 static void cli_cmd_dump(const char *cmd_name, char *args) {

--- a/boards/cats_rev1Pro/src/config/cats_config.h
+++ b/boards/cats_rev1Pro/src/config/cats_config.h
@@ -66,7 +66,7 @@ extern cats_config_u global_cats_config;
 
 /** cats config initialization **/
 void cc_init();
-void cc_defaults();
+void cc_defaults(bool use_default_outputs);
 
 /** persistence functions - return true on success **/
 bool cc_load();


### PR DESCRIPTION
Liftoff acceleration threshold: 3.5gs
Main deployment altitude: 200m
Apogee event: HIGH_CURRENT_ONE - 1
Post-apogee event: HIGH_CURRENT_TWO - 2

This configuration is set with the `defaults` command.
The configuration without active HIGH_CURRENT channels can be set with
`defaults --no-outputs`.

Closes #77 