### PR TITLE
Add support for printing of generic config.

### DIFF
--- a/boards/cats_rev1Pro/src/cli/cli.c
+++ b/boards/cats_rev1Pro/src/cli/cli.c
@@ -376,8 +376,8 @@ static void print_value_pointer(const char *cmdName, const cli_value_t *var, con
   }
 }
 
-void cli_print_var(const char *cmdName, const cli_value_t *var, bool full) {
-  const void *ptr = var->pdata;
+void cli_print_var(const char *cmdName, const cats_config_u *cfg, const cli_value_t *var, bool full) {
+  const void *ptr = get_cats_config_member_ptr(cfg, var);
 
   print_value_pointer(cmdName, var, ptr, full);
 }

--- a/boards/cats_rev1Pro/src/cli/cli.h
+++ b/boards/cats_rev1Pro/src/cli/cli.h
@@ -40,7 +40,7 @@ char *skip_space(char *buffer);
 uint16_t cli_get_setting_index(char *name, uint8_t length);
 void get_min_max(const cli_value_t *var, int *min, int *max);
 
-void cli_print_var(const char *cmdName, const cli_value_t *var, bool full);
+void cli_print_var(const char *cmdName, const cats_config_u *cfg, const cli_value_t *var, bool full);
 void cli_print_var_range(const cli_value_t *var);
 
 const char *next_arg(const char *current_arg);

--- a/boards/cats_rev1Pro/src/cli/cli_commands.c
+++ b/boards/cats_rev1Pro/src/cli/cli_commands.c
@@ -110,6 +110,8 @@ static void cli_set_var(const cli_value_t *var, uint32_t value);
 
 static void fill_buf(uint8_t *buf, size_t buf_sz);
 
+static void print_cats_config(const char *cmd_name, const cats_config_u *cfg, bool print_limits);
+
 /** CLI command function definitions **/
 
 static void cli_cmd_help(const char *cmd_name, char *args) {
@@ -173,7 +175,7 @@ static void cli_cmd_get(const char *cmd_name, char *args) {
         cli_print_linefeed();
       }
       cli_printf("%s = ", value_table[i].name);
-      cli_print_var(cmd_name, val, 0);
+      cli_print_var(cmd_name, &global_cats_config, val, 0);
       cli_print_linefeed();
       cli_print_var_range(val);
       // cliPrintVarDefault(cmd_name, val);
@@ -194,13 +196,9 @@ static void cli_cmd_set(const char *cmd_name, char *args) {
   if (len == 0 || (len == 1 && args[0] == '*')) {
     cli_print_line("Current settings: ");
 
-    for (uint32_t i = 0; i < value_table_entry_count; i++) {
-      const cli_value_t *val = &value_table[i];
-      cli_printf("%s = ", value_table[i].name);
-      // when len is 1 (when * is passed as argument), it will print min/max values as well, for gui
-      cli_print_var(cmd_name, val, len);
-      cli_print_linefeed();
-    }
+    // when len is 1 (when * is passed as argument), it will print min/max values as well, for gui
+    print_cats_config(cmd_name, &global_cats_config, len);
+
   } else if ((eqptr = strstr(args, "=")) != NULL) {
     // has equals
 
@@ -271,6 +269,8 @@ static void cli_cmd_set(const char *cmd_name, char *args) {
           // skip spaces
           valPtr = skip_space(valPtr);
 
+          const void *var_ptr = get_cats_config_member_ptr(&global_cats_config, val);
+
           // process substring starting at valPtr
           // note: no need to copy substrings for atoi()
           //       it stops at the first character that cannot be converted...
@@ -278,7 +278,7 @@ static void cli_cmd_set(const char *cmd_name, char *args) {
             default:
             case VAR_UINT8: {
               // fetch data pointer
-              uint8_t *data = (uint8_t *)val->pdata + i;
+              uint8_t *data = (uint8_t *)var_ptr + i;
               // store value
               *data = (uint8_t)atoi((const char *)valPtr);
             }
@@ -286,7 +286,7 @@ static void cli_cmd_set(const char *cmd_name, char *args) {
             break;
             case VAR_INT8: {
               // fetch data pointer
-              int8_t *data = (int8_t *)val->pdata + i;
+              int8_t *data = (int8_t *)var_ptr + i;
               // store value
               *data = (int8_t)atoi((const char *)valPtr);
             }
@@ -294,7 +294,7 @@ static void cli_cmd_set(const char *cmd_name, char *args) {
             break;
             case VAR_UINT16: {
               // fetch data pointer
-              uint16_t *data = (uint16_t *)val->pdata + i;
+              uint16_t *data = (uint16_t *)var_ptr + i;
               // store value
               *data = (uint16_t)atoi((const char *)valPtr);
             }
@@ -302,7 +302,7 @@ static void cli_cmd_set(const char *cmd_name, char *args) {
             break;
             case VAR_INT16: {
               // fetch data pointer
-              int16_t *data = (int16_t *)val->pdata + i;
+              int16_t *data = (int16_t *)var_ptr + i;
               // store value
               *data = (int16_t)atoi((const char *)valPtr);
             }
@@ -310,7 +310,7 @@ static void cli_cmd_set(const char *cmd_name, char *args) {
             break;
             case VAR_UINT32: {
               // fetch data pointer
-              uint32_t *data = (uint32_t *)val->pdata + i;
+              uint32_t *data = (uint32_t *)var_ptr + i;
               // store value
               *data = (uint32_t)strtoul((const char *)valPtr, NULL, 10);
             }
@@ -332,7 +332,7 @@ static void cli_cmd_set(const char *cmd_name, char *args) {
 
     if (value_changed) {
       cli_printf("%s set to ", val->name);
-      cli_print_var(cmd_name, val, 0);
+      cli_print_var(cmd_name, &global_cats_config, val, 0);
       if (val->cb != NULL) {
         val->cb(val);
       }
@@ -364,15 +364,10 @@ static void cli_cmd_defaults(const char *cmd_name, char *args) {
 
 static void cli_cmd_dump(const char *cmd_name, char *args) {
   const uint32_t len = strlen(args);
-  cli_printf("#Configuration dump");
-  cli_print_linefeed();
-  for (uint32_t i = 0; i < value_table_entry_count; i++) {
-    const cli_value_t *val = &value_table[i];
-    cli_printf("set %s = ", value_table[i].name);
-    // when len is 1 (when * is passed as argument), it will print min/max values as well
-    cli_print_var(cmd_name, val, len);
-    cli_print_linefeed();
-  }
+  cli_print_linef("#Configuration dump");
+
+  print_cats_config(cmd_name, &global_cats_config, len);
+
   cli_printf("#End of configuration dump");
 }
 
@@ -493,7 +488,6 @@ static void cli_cmd_rm(const char *cmd_name, char *args) {
   }
 }
 
-extern const struct lfs_config lfs_cfg;
 static void cli_cmd_rec_info(const char *cmd_name, char *args) {
   const lfs_ssize_t curr_sz_blocks = lfs_fs_size(&lfs);
   const int32_t num_flights = lfs_cnt("/flights", LFS_TYPE_REG);
@@ -848,7 +842,8 @@ static void print_timer_config() {
 }
 
 static void cli_set_var(const cli_value_t *var, const uint32_t value) {
-  void *ptr = var->pdata;
+  const void *ptr = get_cats_config_member_ptr(&global_cats_config, var);
+
   uint32_t work_value;
   uint32_t mask;
 
@@ -913,5 +908,19 @@ static void fill_buf(uint8_t *buf, size_t buf_sz) {
   for (uint32_t i = 0; i < buf_sz / 2; ++i) {
     buf[i] = i * 2;
     buf[buf_sz - i - 1] = i * 2 + 1;
+  }
+}
+
+static void print_cats_config(const char *cmd_name, const cats_config_u *cfg, bool print_limits) {
+  char *prefix = "";
+  if (!strcmp(cmd_name, "dump")) {
+    prefix = "set ";
+  }
+
+  for (uint32_t i = 0; i < value_table_entry_count; i++) {
+    const cli_value_t *val = &value_table[i];
+    cli_printf("%s%s = ", prefix, value_table[i].name);
+    cli_print_var(cmd_name, cfg, val, print_limits);
+    cli_print_linefeed();
   }
 }

--- a/boards/cats_rev1Pro/src/cli/settings.c
+++ b/boards/cats_rev1Pro/src/cli/settings.c
@@ -20,6 +20,8 @@
 #include "cli/settings.h"
 #include "util/enum_str_maps.h"
 
+#include <stddef.h>
+
 #define LOOKUP_TABLE_ENTRY(name) \
   { name, ARRAYLEN(name) }
 
@@ -27,97 +29,119 @@ const lookup_table_entry_t lookup_tables[] = {
     LOOKUP_TABLE_ENTRY(boot_state_map),
     LOOKUP_TABLE_ENTRY(event_map),
     LOOKUP_TABLE_ENTRY(action_map),
-    {(const char* const*)recorder_speed_map, NUM_REC_SPEEDS},
+    {(const char *const *)recorder_speed_map, NUM_REC_SPEEDS},
 };
 
 #undef LOOKUP_TABLE_ENTRY
 
 const cli_value_t value_table[] = {
-    {"boot_state", VAR_UINT32 | MODE_LOOKUP, {.lookup = {TABLE_BOOTSTATE}}, &global_cats_config.config.boot_state},
+    {"boot_state", VAR_UINT32 | MODE_LOOKUP, {.lookup = {TABLE_BOOTSTATE}}, offsetof(cats_config_u, config.boot_state)},
 
     // Control
     {"main_altitude",
      VAR_UINT16,
      {.minmax_unsigned = {10, 65535}},
-     &global_cats_config.config.control_settings.main_altitude},
+     offsetof(cats_config_u, config.control_settings.main_altitude)},
     {"acc_threshold",
      VAR_UINT16,
      {.minmax_unsigned = {15, 80}},
-     &global_cats_config.config.control_settings.liftoff_acc_threshold},
+     offsetof(cats_config_u, config.control_settings.liftoff_acc_threshold)},
     {"mach_timer_duration",
      VAR_UINT16,
      {.minmax_unsigned = {0, 60000}},
-     &global_cats_config.config.control_settings.mach_timer_duration},
+     offsetof(cats_config_u, config.control_settings.mach_timer_duration)},
 
     // Timers
     {"timer1_start",
      VAR_UINT8 | MODE_LOOKUP,
      {.lookup = {TABLE_EVENTS}},
-     &global_cats_config.config.timers[0].start_event},
+     offsetof(cats_config_u, config.timers[0].start_event)},
     {"timer1_trigger",
      VAR_UINT8 | MODE_LOOKUP,
      {.lookup = {TABLE_EVENTS}},
-     &global_cats_config.config.timers[0].trigger_event},
-    {"timer1_duration", VAR_UINT32, {.u32_max = 1200000}, &global_cats_config.config.timers[0].duration},
+     offsetof(cats_config_u, config.timers[0].trigger_event)},
+    {"timer1_duration", VAR_UINT32, {.u32_max = 1200000}, offsetof(cats_config_u, config.timers[0].duration)},
     {"timer2_start",
      VAR_UINT8 | MODE_LOOKUP,
      {.lookup = {TABLE_EVENTS}},
-     &global_cats_config.config.timers[1].start_event},
+     offsetof(cats_config_u, config.timers[1].start_event)},
     {"timer2_trigger",
      VAR_UINT8 | MODE_LOOKUP,
      {.lookup = {TABLE_EVENTS}},
-     &global_cats_config.config.timers[1].trigger_event},
-    {"timer2_duration", VAR_UINT32, {.u32_max = 1200000}, &global_cats_config.config.timers[1].duration},
+     offsetof(cats_config_u, config.timers[1].trigger_event)},
+    {"timer2_duration", VAR_UINT32, {.u32_max = 1200000}, offsetof(cats_config_u, config.timers[1].duration)},
     {"timer3_start",
      VAR_UINT8 | MODE_LOOKUP,
      {.lookup = {TABLE_EVENTS}},
-     &global_cats_config.config.timers[2].start_event},
+     offsetof(cats_config_u, config.timers[2].start_event)},
     {"timer3_trigger",
      VAR_UINT8 | MODE_LOOKUP,
      {.lookup = {TABLE_EVENTS}},
-     &global_cats_config.config.timers[2].trigger_event},
-    {"timer3_duration", VAR_UINT32, {.u32_max = 1200000}, &global_cats_config.config.timers[2].duration},
+     offsetof(cats_config_u, config.timers[2].trigger_event)},
+    {"timer3_duration", VAR_UINT32, {.u32_max = 1200000}, offsetof(cats_config_u, config.timers[2].duration)},
     {"timer4_start",
      VAR_UINT8 | MODE_LOOKUP,
      {.lookup = {TABLE_EVENTS}},
-     &global_cats_config.config.timers[3].start_event},
+     offsetof(cats_config_u, config.timers[3].start_event)},
     {"timer4_trigger",
      VAR_UINT8 | MODE_LOOKUP,
      {.lookup = {TABLE_EVENTS}},
-     &global_cats_config.config.timers[3].trigger_event},
-    {"timer4_duration", VAR_UINT32, {.u32_max = 1200000}, &global_cats_config.config.timers[3].duration},
+     offsetof(cats_config_u, config.timers[3].trigger_event)},
+    {"timer4_duration", VAR_UINT32, {.u32_max = 1200000}, offsetof(cats_config_u, config.timers[3].duration)},
 
     // Events
-    {"ev_moving", VAR_INT16 | MODE_ARRAY, {.array = {.length = 16}}, global_cats_config.config.action_array[EV_MOVING]},
-    {"ev_ready", VAR_INT16 | MODE_ARRAY, {.array = {.length = 16}}, global_cats_config.config.action_array[EV_READY]},
+    {"ev_moving",
+     VAR_INT16 | MODE_ARRAY,
+     {.array = {.length = 16}},
+     offsetof(cats_config_u, config.action_array[EV_MOVING])},
+    {"ev_ready",
+     VAR_INT16 | MODE_ARRAY,
+     {.array = {.length = 16}},
+     offsetof(cats_config_u, config.action_array[EV_READY])},
     {"ev_liftoff",
      VAR_INT16 | MODE_ARRAY,
      {.array = {.length = 16}},
-     global_cats_config.config.action_array[EV_LIFTOFF]},
-    {"ev_burnout", VAR_INT16 | MODE_ARRAY, {.array = {.length = 16}}, global_cats_config.config.action_array[EV_MAX_V]},
-    {"ev_apogee", VAR_INT16 | MODE_ARRAY, {.array = {.length = 16}}, global_cats_config.config.action_array[EV_APOGEE]},
+     offsetof(cats_config_u, config.action_array[EV_LIFTOFF])},
+    {"ev_burnout",
+     VAR_INT16 | MODE_ARRAY,
+     {.array = {.length = 16}},
+     offsetof(cats_config_u, config.action_array[EV_MAX_V])},
+    {"ev_apogee",
+     VAR_INT16 | MODE_ARRAY,
+     {.array = {.length = 16}},
+     offsetof(cats_config_u, config.action_array[EV_APOGEE])},
     {"ev_lowalt",
      VAR_INT16 | MODE_ARRAY,
      {.array = {.length = 16}},
-     global_cats_config.config.action_array[EV_POST_APOGEE]},
+     offsetof(cats_config_u, config.action_array[EV_POST_APOGEE])},
     {"ev_touchdown",
      VAR_INT16 | MODE_ARRAY,
      {.array = {.length = 16}},
-     global_cats_config.config.action_array[EV_TOUCHDOWN]},
+     offsetof(cats_config_u, config.action_array[EV_TOUCHDOWN])},
     {"ev_custom1",
      VAR_INT16 | MODE_ARRAY,
      {.array = {.length = 16}},
-     global_cats_config.config.action_array[EV_CUSTOM_1]},
+     offsetof(cats_config_u, config.action_array[EV_CUSTOM_1])},
     {"ev_custom2",
      VAR_INT16 | MODE_ARRAY,
      {.array = {.length = 16}},
-     global_cats_config.config.action_array[EV_CUSTOM_2]},
+     offsetof(cats_config_u, config.action_array[EV_CUSTOM_2])},
 
     // Servo position
-    {"servo1_init_pos", VAR_INT16, {.minmax_unsigned = {0, 180}}, &global_cats_config.config.initial_servo_position[0]},
-    {"servo2_init_pos", VAR_INT16, {.minmax_unsigned = {0, 180}}, &global_cats_config.config.initial_servo_position[1]},
+    {"servo1_init_pos",
+     VAR_INT16,
+     {.minmax_unsigned = {0, 180}},
+     offsetof(cats_config_u, config.initial_servo_position[0])},
+    {"servo2_init_pos",
+     VAR_INT16,
+     {.minmax_unsigned = {0, 180}},
+     offsetof(cats_config_u, config.initial_servo_position[1])},
 
-    {"rec_elements", VAR_UINT32, {.u32_max = UINT32_MAX}, &global_cats_config.config.rec_mask},
-    {"rec_speed", VAR_UINT8 | MODE_LOOKUP, {.lookup = {TABLE_SPEEDS}}, &global_cats_config.config.rec_speed_idx}};
+    {"rec_elements", VAR_UINT32, {.u32_max = UINT32_MAX}, offsetof(cats_config_u, config.rec_mask)},
+    {"rec_speed", VAR_UINT8 | MODE_LOOKUP, {.lookup = {TABLE_SPEEDS}}, offsetof(cats_config_u, config.rec_speed_idx)}};
 
 const uint16_t value_table_entry_count = ARRAYLEN(value_table);
+
+void *get_cats_config_member_ptr(const cats_config_u *cfg, const cli_value_t *var) {
+  return ((uint8_t *)cfg) + var->member_offset;
+}

--- a/boards/cats_rev1Pro/src/cli/settings.h
+++ b/boards/cats_rev1Pro/src/cli/settings.h
@@ -98,7 +98,7 @@ typedef struct cli_value {
   const char *name;
   const uint8_t type;  // see cli_value_flag_e
   const cli_value_config_t config;
-  void *pdata;
+  uint16_t member_offset;
   callback_f cb;
 } __attribute__((packed)) cli_value_t;
 
@@ -106,3 +106,5 @@ extern const lookup_table_entry_t lookup_tables[];
 extern const uint16_t value_table_entry_count;
 
 extern const cli_value_t value_table[];
+
+void *get_cats_config_member_ptr(const cats_config_u *cfg, const cli_value_t *var);


### PR DESCRIPTION
Currently printing of the config is directly tied to the
global_cats_config variable.

This patch replaces storing the direct pointers to global_cats_config
members by keeping track of their offset, which makes the functions
parameterizable with an arbitrary instance of cats_config_u.

This work is a prerequisite for adding the flight config to the stats
file since we have to load the saved config to a new variable when we
want to print it out.
