### PR TITLE
Implement Adaptive Power Level

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -146,7 +146,7 @@ RawStringFormats:
     CanonicalDelimiter: ''
     BasedOnStyle:    google
 ReflowComments:  true
-SortIncludes:    CaseSensitive
+SortIncludes:    true
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false

--- a/firmware/src/cli/settings.c
+++ b/firmware/src/cli/settings.c
@@ -30,7 +30,7 @@ const lookup_table_entry_t lookup_tables[] = {
     LOOKUP_TABLE_ENTRY(event_map),
     LOOKUP_TABLE_ENTRY(action_map),
 #ifdef CATS_VEGA
-    LOOKUP_TABLE_ENTRY(power_map),
+    LOOKUP_TABLE_ENTRY(on_off_map),
 #endif
     {(const char *const *)recorder_speed_map, NUM_REC_SPEEDS},
 };
@@ -51,7 +51,6 @@ const cli_value_t value_table[] = {
      VAR_UINT16,
      {.minmax_unsigned = {10, 65535}},
      offsetof(cats_config_u, config.control_settings.main_altitude)},
-
 
     // Timers
     {"timer1_start",
@@ -142,9 +141,13 @@ const cli_value_t value_table[] = {
 #ifdef CATS_VEGA
     {"tele_link_phrase", VAR_UINT8 | MODE_STRING, .config.string = {4, 8},
      offsetof(cats_config_u, config.telemetry_settings.link_phrase)},
-    {"tele_power_level",VAR_UINT8,     {.minmax_unsigned = {16, 30}},
+    {"tele_power_level",
+     VAR_UINT8,
+     {.minmax_unsigned = {16, 30}},
      offsetof(cats_config_u, config.telemetry_settings.power_level)},
-    {"tele_adaptive_power",VAR_UINT8 | MODE_LOOKUP, {.lookup = {TABLE_POWER}},
+    {"tele_adaptive_power",
+     VAR_UINT8 | MODE_LOOKUP,
+     {.lookup = {TABLE_POWER}},
      offsetof(cats_config_u, config.telemetry_settings.adaptive_power)},
 #endif
 

--- a/firmware/src/cli/settings.c
+++ b/firmware/src/cli/settings.c
@@ -29,6 +29,9 @@
 const lookup_table_entry_t lookup_tables[] = {
     LOOKUP_TABLE_ENTRY(event_map),
     LOOKUP_TABLE_ENTRY(action_map),
+#ifdef CATS_VEGA
+    LOOKUP_TABLE_ENTRY(power_map),
+#endif
     {(const char *const *)recorder_speed_map, NUM_REC_SPEEDS},
 };
 
@@ -141,6 +144,8 @@ const cli_value_t value_table[] = {
      offsetof(cats_config_u, config.telemetry_settings.link_phrase)},
     {"tele_power_level",VAR_UINT8,     {.minmax_unsigned = {16, 30}},
      offsetof(cats_config_u, config.telemetry_settings.power_level)},
+    {"tele_adaptive_power",VAR_UINT8 | MODE_LOOKUP, {.lookup = {TABLE_POWER}},
+     offsetof(cats_config_u, config.telemetry_settings.adaptive_power)},
 #endif
 
     {"rec_elements", VAR_UINT32, {.u32_max = UINT32_MAX}, offsetof(cats_config_u, config.rec_mask)},

--- a/firmware/src/cli/settings.h
+++ b/firmware/src/cli/settings.h
@@ -25,6 +25,9 @@
 
 typedef enum { TABLE_EVENTS = 0,
                TABLE_ACTIONS,
+#ifdef CATS_VEGA
+               TABLE_POWER,
+#endif
                TABLE_SPEEDS } lookup_table_index_e;
 
 typedef struct {

--- a/firmware/src/config/cats_config.c
+++ b/firmware/src/config/cats_config.c
@@ -70,6 +70,7 @@ const cats_config_u DEFAULT_CONFIG = {.config.config_version = CONFIG_VERSION,
 #ifdef CATS_VEGA
                                       .config.telemetry_settings.power_level = 20,
                                       .config.telemetry_settings.link_phrase = "",
+                                      .config.telemetry_settings.adaptive_power = OFF,
 #endif
 };
 

--- a/firmware/src/tasks/task_telemetry.c
+++ b/firmware/src/tasks/task_telemetry.c
@@ -42,8 +42,8 @@ typedef enum {
   STATE_CRC,
 } state_e;
 
-#define INDEX_OP  0
-#define INDEX_LEN 1
+#define INDEX_OP       0
+#define INDEX_LEN      1
 #define TELE_MAX_POWER 30
 
 void send_setting(uint8_t command, uint8_t value);
@@ -219,7 +219,7 @@ void parse_tx_msg(packed_tx_msg_t* rx_payload) {
     }
 
     /* Go to high power mode if adaptive power is enabled */
-    if(global_cats_config.config.telemetry_settings.adaptive_power == 1){
+    if (global_cats_config.config.telemetry_settings.adaptive_power == ON) {
       if ((new_fsm_enum != old_fsm_enum) && (new_fsm_enum == THRUSTING)) {
         send_setting(CMD_POWER_LEVEL, TELE_MAX_POWER);
       }
@@ -227,7 +227,6 @@ void parse_tx_msg(packed_tx_msg_t* rx_payload) {
         send_setting(CMD_POWER_LEVEL, global_cats_config.config.telemetry_settings.power_level);
       }
     }
-
 
     old_fsm_enum = new_fsm_enum;
 

--- a/firmware/src/tasks/task_telemetry.c
+++ b/firmware/src/tasks/task_telemetry.c
@@ -44,6 +44,7 @@ typedef enum {
 
 #define INDEX_OP  0
 #define INDEX_LEN 1
+#define TELE_MAX_POWER 30
 
 void send_setting(uint8_t command, uint8_t value);
 bool parse(uint8_t op_code, const uint8_t* buffer, uint32_t length, gnss_data_t* gnss);
@@ -209,13 +210,24 @@ void parse_tx_msg(packed_tx_msg_t* rx_payload) {
     new_fsm_enum = global_flight_state.flight_state;
 
     /* Log GNSS time when changing to THRUSTING. */
-    if ((new_fsm_enum != old_fsm_enum) && (new_fsm_enum == READY)) {
+    if ((new_fsm_enum != old_fsm_enum) && (new_fsm_enum == THRUSTING)) {
       /* Time will be 0 if it was never received. */
       /* TODO: Keep track of the last timestamp when the GNSS time was received and add the difference between that and
        * current one to the GNSS time. This should be done when the date information is also sent via UART. */
       log_info("Logging GNSS Time: %02hu:%02hu:%02hu UTC", gnss_data.time.hour, gnss_data.time.min, gnss_data.time.sec);
       global_flight_stats.liftoff_time = gnss_data.time;
     }
+
+    /* Go to high power mode if adaptive power is enabled */
+    if(global_cats_config.config.telemetry_settings.adaptive_power == 1){
+      if ((new_fsm_enum != old_fsm_enum) && (new_fsm_enum == THRUSTING)) {
+        send_setting(CMD_POWER_LEVEL, TELE_MAX_POWER);
+      }
+      if ((new_fsm_enum != old_fsm_enum) && (new_fsm_enum == TOUCHDOWN)) {
+        send_setting(CMD_POWER_LEVEL, global_cats_config.config.telemetry_settings.power_level);
+      }
+    }
+
 
     old_fsm_enum = new_fsm_enum;
 

--- a/firmware/src/util/enum_str_maps.c
+++ b/firmware/src/util/enum_str_maps.c
@@ -38,7 +38,10 @@ const char* const action_map[17] = {
 char* recorder_speed_map[NUM_REC_SPEEDS] = {};
 
 #ifdef CATS_VEGA
-const char* const power_map[2] = { "OFF", "ON", };
+const char* const on_off_map[2] = {
+    "OFF",
+    "ON",
+};
 #endif
 
 void init_recorder_speed_map() {

--- a/firmware/src/util/enum_str_maps.c
+++ b/firmware/src/util/enum_str_maps.c
@@ -37,6 +37,10 @@ const char* const action_map[17] = {
 
 char* recorder_speed_map[NUM_REC_SPEEDS] = {};
 
+#ifdef CATS_VEGA
+const char* const power_map[2] = { "OFF", "ON", };
+#endif
+
 void init_recorder_speed_map() {
   for (uint32_t i = 0; i < NUM_REC_SPEEDS; ++i) {
     recorder_speed_map[i] = (char*)pvPortMalloc(14 * sizeof(char));

--- a/firmware/src/util/enum_str_maps.h
+++ b/firmware/src/util/enum_str_maps.h
@@ -23,7 +23,7 @@ extern const char *const event_map[9];
 extern const char *const action_map[17];
 
 #ifdef CATS_VEGA
-extern const char* const power_map[2];
+extern const char *const on_off_map[2];
 #endif
 
 extern char *recorder_speed_map[NUM_REC_SPEEDS];

--- a/firmware/src/util/enum_str_maps.h
+++ b/firmware/src/util/enum_str_maps.h
@@ -22,6 +22,10 @@ extern const char *const fsm_map[9];
 extern const char *const event_map[9];
 extern const char *const action_map[17];
 
+#ifdef CATS_VEGA
+extern const char* const power_map[2];
+#endif
+
 extern char *recorder_speed_map[NUM_REC_SPEEDS];
 
 void init_recorder_speed_map();

--- a/firmware/src/util/types.h
+++ b/firmware/src/util/types.h
@@ -194,10 +194,16 @@ typedef struct {
   int16_t arg;
 } config_action_t;
 
+typedef enum {
+  OFF,
+  ON
+} adaptive_power_e;
+
 #ifdef CATS_VEGA
 typedef struct {
   uint8_t link_phrase[8];
   uint8_t power_level;
+  adaptive_power_e adaptive_power;
 } config_telemetry_t;
 #endif
 


### PR DESCRIPTION
If enabled in the CLI, the configured power is the default level and the max level is set to 30 dBm. At Liftoff the maximum power is then set and at touchdown it is set to the configured power again. If disabled, the configured power stays the same.

Closes #168 