### PR TITLE
November Fixes

### DIFF
--- a/firmware/.clang-tidy
+++ b/firmware/.clang-tidy
@@ -1,0 +1,19 @@
+Checks: >
+  llvm-*,
+  bugprone-*,
+  modernize-*,
+  -modernize-use-trailing-return-type,
+  clang-analyzer-*,
+  cppcoreguidelines-*,
+  hicpp-*,
+  misc-*,
+  performance-*,
+  portability-*,
+  readability-*
+
+# Example for future CheckOptions configuration
+#CheckOptions:
+#  - key: bugprone-argument-comment.StrictMode
+#    value: 1
+
+FormatStyle: 'file'

--- a/firmware/src/drivers/spi.cpp
+++ b/firmware/src/drivers/spi.cpp
@@ -62,7 +62,7 @@ void spi_init(SPI_BUS *bus) {
   return 1;
 }
 
-void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi) {
+extern "C" void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi) {
   for (int i = 0; i < instance_count; i++) {
     if (buses[i]->busy) {
       HAL_GPIO_WritePin(buses[i]->cs_port, buses[i]->cs_pin, (GPIO_PinState)(!buses[i]->cs_type));
@@ -71,7 +71,7 @@ void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi) {
   }
 }
 
-void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi) {
+extern "C" void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi) {
   for (int i = 0; i < instance_count; i++) {
     if (buses[i]->busy) {
       HAL_GPIO_WritePin(buses[i]->cs_port, buses[i]->cs_pin, (GPIO_PinState)(!buses[i]->cs_type));

--- a/firmware/src/drivers/usb/usbd_cdc_if.cpp
+++ b/firmware/src/drivers/usb/usbd_cdc_if.cpp
@@ -260,7 +260,7 @@ static int8_t CDC_TransmitCplt_FS(uint8_t *Buf, uint32_t *Len, uint8_t epnum) {
   return result;
 }
 
-void TIMUsb_IRQHandler(void) { HAL_TIM_IRQHandler(&TimHandle); }
+extern "C" void TIMUsb_IRQHandler(void) { HAL_TIM_IRQHandler(&TimHandle); }
 
 void CDC_Transmit_Elapsed() {
   USBD_CDC_HandleTypeDef *hcdc = (USBD_CDC_HandleTypeDef *)hUsbDeviceFS.pClassData;

--- a/firmware/src/drivers/usb/usbd_desc.cpp
+++ b/firmware/src/drivers/usb/usbd_desc.cpp
@@ -67,7 +67,7 @@
 #define USBD_LANGID_STRING           1033
 #define USBD_MANUFACTURER_STRING     "Control and Telemetry Systems"
 #define USBD_PID_FS                  22336
-#define USBD_PRODUCT_STRING_FS       "CATS v2"
+#define USBD_PRODUCT_STRING_FS       "CATS Vega"
 #define USBD_CONFIGURATION_STRING_FS "CDC Config"
 #define USBD_INTERFACE_STRING_FS     "CDC Interface"
 

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -111,7 +111,7 @@ int main(void) {
  * @param  htim : TIM handle
  * @retval None
  */
-void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) {
+extern "C" void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) {
   if (htim->Instance == TIM1) {
     HAL_IncTick();
   }

--- a/firmware/src/tasks/task_telemetry.cpp
+++ b/firmware/src/tasks/task_telemetry.cpp
@@ -335,7 +335,7 @@ void send_tx_payload(uint8_t* payload, uint32_t length) {
   HAL_UART_Transmit(&TELEMETRY_UART_HANDLE, out, length + 3, 2);
 }
 
-void HAL_UART_RxCpltCallback(UART_HandleTypeDef* huart) {
+extern "C" void HAL_UART_RxCpltCallback(UART_HandleTypeDef* huart) {
   if (huart == &TELEMETRY_UART_HANDLE) {
     uint8_t tmp = uart_char;
     HAL_UART_Receive_IT(&TELEMETRY_UART_HANDLE, &uart_char, 1);


### PR DESCRIPTION
1. Change usb_cdc_if.c -> usb_cdc_if.cpp

This was the last file in src/ that remained in C. We needed to add extern "C" to prevent name mangling by C++, so that the linker recognizes that it should override the __weak function of the same name.

2. Add 'extern "C"' to other potentially __weak Callbacks

Just in case.

3. Add first version of .clang-tidy

Will be adjusted as needed.

4. Rename USB_PRODUCT_STRING_FS from "CATS v2" -> "CATS Vega"