### PR TITLE
Detect Fast Cycling of States. Initialize USB Device if USB is detected after Startup.

### DIFF
--- a/firmware/src/config/globals.cpp
+++ b/firmware/src/config/globals.cpp
@@ -213,6 +213,7 @@ osMessageQueueId_t rec_cmd_queue;
 osMessageQueueId_t event_queue;
 
 volatile bool global_usb_detection = false;
+volatile bool usb_device_initialized = false;
 volatile bool usb_communication_complete = false;
 volatile bool simulation_started = false;
 

--- a/firmware/src/config/globals.h
+++ b/firmware/src/config/globals.h
@@ -76,6 +76,7 @@ extern osMessageQueueId_t rec_cmd_queue;
 extern osMessageQueueId_t event_queue;
 
 extern volatile bool global_usb_detection;
+extern volatile bool usb_device_initialized;
 extern volatile bool usb_communication_complete;
 extern volatile bool simulation_started;
 

--- a/firmware/src/control/flight_phases.cpp
+++ b/firmware/src/control/flight_phases.cpp
@@ -206,7 +206,7 @@ static void check_coasting_phase(flight_fsm_t *fsm_state, estimation_output_t st
 
   if (fsm_state->memory[0] > APOGEE_SAFETY_COUNTER) {
     /* If the duration between thrusting and apogee is smaller than defined, go to touchdown */
-    if ((osKernelGetTickCount() - fsm_state->thrust_trigger_time) < MIN_TIME_BETWEEN_THRUSTING_APOGEE) {
+    if ((osKernelGetTickCount() - fsm_state->thrust_trigger_time) < MIN_TICK_COUNTS_BETWEEN_THRUSTING_APOGEE) {
       change_state_to(TOUCHDOWN, EV_TOUCHDOWN, fsm_state);
     } else {
       change_state_to(DROGUE, EV_APOGEE, fsm_state);

--- a/firmware/src/control/flight_phases.cpp
+++ b/firmware/src/control/flight_phases.cpp
@@ -205,7 +205,12 @@ static void check_coasting_phase(flight_fsm_t *fsm_state, estimation_output_t st
   }
 
   if (fsm_state->memory[0] > APOGEE_SAFETY_COUNTER) {
-    change_state_to(DROGUE, EV_APOGEE, fsm_state);
+    /* If the duration between thrusting and apogee is smaller than defined, go to touchdown */
+    if ((osKernelGetTickCount() - fsm_state->thrust_trigger_time) < MIN_TIME_BETWEEN_THRUSTING_APOGEE) {
+      change_state_to(TOUCHDOWN, EV_TOUCHDOWN, fsm_state);
+    } else {
+      change_state_to(DROGUE, EV_APOGEE, fsm_state);
+    }
   }
 }
 
@@ -251,6 +256,10 @@ static void clear_fsm_memory(flight_fsm_t *fsm_state) {
 }
 
 static void change_state_to(flight_fsm_e new_state, cats_event_e event_to_trigger, flight_fsm_t *fsm_state) {
+  if (fsm_state->flight_state == THRUSTING) {
+    fsm_state->thrust_trigger_time = osKernelGetTickCount();
+  }
+
   trigger_event(event_to_trigger);
   osEventFlagsClear(fsm_flag_id, 0xFF);
   osEventFlagsSet(fsm_flag_id, new_state);

--- a/firmware/src/control/flight_phases.h
+++ b/firmware/src/control/flight_phases.h
@@ -60,7 +60,8 @@
 
 /* DROGUE */
 // num iterations, height needs to be smaller than user-defined for at least 0.3 s for the transition DROGUE -> MAIN
-#define MAIN_SAFETY_COUNTER 30
+#define MAIN_SAFETY_COUNTER               30
+#define MIN_TIME_BETWEEN_THRUSTING_APOGEE 1500
 
 /* MAIN */
 // m/s, velocity needs to be smaller than this to detect touchdown

--- a/firmware/src/control/flight_phases.h
+++ b/firmware/src/control/flight_phases.h
@@ -60,8 +60,9 @@
 
 /* DROGUE */
 // num iterations, height needs to be smaller than user-defined for at least 0.3 s for the transition DROGUE -> MAIN
-#define MAIN_SAFETY_COUNTER               30
-#define MIN_TIME_BETWEEN_THRUSTING_APOGEE 1500
+#define MAIN_SAFETY_COUNTER 30
+// tick counts [ms]
+#define MIN_TICK_COUNTS_BETWEEN_THRUSTING_APOGEE 1500
 
 /* MAIN */
 // m/s, velocity needs to be smaller than this to detect touchdown

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -23,11 +23,11 @@
 
 #include "drivers/adc.h"
 
+#include "config/globals.h"
 #include "util/battery.h"
 #include "util/buzzer_handler.h"
 #include "util/log.h"
 #include "util/task_util.h"
-#include "util/types.h"
 
 #include "init/config.h"
 #include "init/system.h"
@@ -56,7 +56,7 @@ int main(void) {
     BootLoaderJump();                                  // Does not return!
   }
 
-  target_init();
+  usb_device_initialized = target_init();
 
   init_logging();
   HAL_Delay(100);

--- a/firmware/src/tasks/task_health_monitor.cpp
+++ b/firmware/src/tasks/task_health_monitor.cpp
@@ -21,6 +21,7 @@
 #include "config/cats_config.h"
 #include "config/globals.h"
 #include "drivers/adc.h"
+#include "usb_device.h"
 #include "util/actions.h"
 #include "util/battery.h"
 #include "util/buzzer_handler.h"
@@ -60,7 +61,11 @@ static void init_communication();
     if (global_usb_detection == true && usb_communication_complete == false) {
       init_communication();
     }
-
+    if (usb_device_initialized == false) {
+      if (HAL_GPIO_ReadPin(USB_DET_GPIO_Port, USB_DET_Pin)) {
+        MX_USB_DEVICE_Init();
+      }
+    }
     // Check battery level
     battery_level_e level = battery_level();
     bool level_changed = (old_level != level);

--- a/firmware/src/tasks/task_health_monitor.cpp
+++ b/firmware/src/tasks/task_health_monitor.cpp
@@ -64,6 +64,7 @@ static void init_communication();
     if (usb_device_initialized == false) {
       if (HAL_GPIO_ReadPin(USB_DET_GPIO_Port, USB_DET_Pin)) {
         MX_USB_DEVICE_Init();
+        usb_device_initialized = true;
       }
     }
     // Check battery level

--- a/firmware/src/tasks/task_state_est.cpp
+++ b/firmware/src/tasks/task_state_est.cpp
@@ -19,17 +19,13 @@
 #include "tasks/task_state_est.h"
 #include "config/globals.h"
 
-#include <cmath>
-
 namespace task {
-
-auto &preprocessing_task = Preprocessing::GetInstance();
 
 void StateEstimation::GetEstimationInputData() {
   /* After apogee we assume that the linear acceleration is zero. This assumption is true if the parachute has been
    * ejected. If this assumption is not done, the linear acceleration will be bad because of movement of the rocket
    * due to parachute forces. */
-
+  auto &preprocessing_task = Preprocessing::GetInstance();
   state_estimation_input_t input = preprocessing_task.GetEstimationInput();
 
   if (m_fsm_enum < DROGUE) {

--- a/firmware/src/tasks/task_state_est.cpp
+++ b/firmware/src/tasks/task_state_est.cpp
@@ -23,12 +23,13 @@
 
 namespace task {
 
+auto &preprocessing_task = Preprocessing::GetInstance();
+
 void StateEstimation::GetEstimationInputData() {
   /* After apogee we assume that the linear acceleration is zero. This assumption is true if the parachute has been
    * ejected. If this assumption is not done, the linear acceleration will be bad because of movement of the rocket
    * due to parachute forces. */
 
-  auto &preprocessing_task = Preprocessing::GetInstance();
   state_estimation_input_t input = preprocessing_task.GetEstimationInput();
 
   if (m_fsm_enum < DROGUE) {

--- a/firmware/src/util/types.h
+++ b/firmware/src/util/types.h
@@ -133,6 +133,7 @@ struct flight_fsm_t {
   float angular_movement[3];
   uint32_t clock_memory;
   uint32_t memory[3];
+  timestamp_t thrust_trigger_time;
   bool state_changed;
 };
 

--- a/firmware/target/VEGA/target.cpp
+++ b/firmware/target/VEGA/target.cpp
@@ -526,7 +526,7 @@ void target_pre_init() {
   RTC_Init();
 }
 
-void target_init() {
+bool target_init() {
   MX_GPIO_Init();
   MX_DMA_Init();
   MX_ADC1_Init();
@@ -538,5 +538,7 @@ void target_init() {
   MX_USART2_UART_Init();
   if (HAL_GPIO_ReadPin(USB_DET_GPIO_Port, USB_DET_Pin)) {
     MX_USB_DEVICE_Init();
+    return true;
   }
+  return false;
 }

--- a/firmware/target/VEGA/target.h
+++ b/firmware/target/VEGA/target.h
@@ -153,7 +153,7 @@ void HAL_TIM_MspPostInit(TIM_HandleTypeDef *htim);
 
 void Error_Handler(void);
 void target_pre_init();
-void target_init();
+bool target_init();
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
1. Fast Cycling of states is discovered, if the time between the event Thrusting and the Event Apogee is smaller than 1.5 seconds.
2. Not tested yet.

closes #166 #159 