### PR TITLE
Stack Size Calculation Fix

### DIFF
--- a/firmware/src/FreeRTOSConfig.h
+++ b/firmware/src/FreeRTOSConfig.h
@@ -59,7 +59,7 @@ extern uint32_t SystemCoreClock;
 #define configTICK_RATE_HZ                      ((TickType_t)1000)
 #define configMAX_PRIORITIES                    (56)  // TODO: check if this can be reduced
 #define configMINIMAL_STACK_SIZE                ((uint16_t)128)
-#define configMAX_TASK_NAME_LEN                 (24)
+#define configMAX_TASK_NAME_LEN                 (32)
 #define configUSE_16_BIT_TICKS                  0
 #define configIDLE_SHOULD_YIELD                 1  // added
 #define configUSE_MUTEXES                       1

--- a/firmware/src/tasks/task.h
+++ b/firmware/src/tasks/task.h
@@ -58,17 +58,15 @@ class Task {
   std::array<uint32_t, STACK_SZ> m_task_buffer{};
   StaticTask_t m_task_control_block{};
 
-  // clang-format off
   const osThreadAttr_t m_task_attributes = {
       // TODO: This is not a good name
       .name = typeid(T).name(),
       .cb_mem = &m_task_control_block,
       .cb_size = sizeof(m_task_control_block),
       .stack_mem = m_task_buffer.data(),
-      .stack_size = m_task_buffer.size(),
+      .stack_size = m_task_buffer.size() * sizeof(uint32_t),
       .priority = (osPriority_t)osPriorityNormal,
   };
-  // clang-format on
 
   static constexpr void RunWrapper(void* task_ptr) noexcept { static_cast<T*>(task_ptr)->Run(); }
 

--- a/firmware/src/tasks/task_health_monitor.cpp
+++ b/firmware/src/tasks/task_health_monitor.cpp
@@ -28,7 +28,6 @@
 #include "util/log.h"
 #include "util/task_util.h"
 
-#include "tasks/task_simulator.h"
 #include "tasks/task_usb_communicator.h"
 
 /** Private Constants **/
@@ -54,7 +53,18 @@ static void init_communication();
 
   uint32_t tick_count = osKernelGetTickCount();
   uint32_t tick_update = osKernelGetTickFreq() / CONTROL_SAMPLING_FREQ;
+
   while (1) {
+    /* Uncomment the code below to enable stack usage monitoring:
+     *
+     * static uint32_t initial_stack_sz = 0xFFFFFFFF;
+     * uint32_t curr_stack_sz = osThreadGetStackSpace(osThreadGetId());
+     * if ((initial_stack_sz == 0xFFFFFFFF) || (curr_stack_sz < initial_stack_sz)) {
+     *  log_raw("[%lu] [Health Monitor] Remaining stack sz: %lu B", osKernelGetTickCount(), curr_stack_sz);
+     *  initial_stack_sz = curr_stack_sz;
+     * }
+     */
+
     /* Get new FSM enum */
     bool fsm_updated = GetNewFsmEnum();
 

--- a/firmware/src/tasks/task_health_monitor.h
+++ b/firmware/src/tasks/task_health_monitor.h
@@ -22,9 +22,9 @@
 
 namespace task {
 
-class HealthMonitor final : public Task<HealthMonitor, 512> {
+class HealthMonitor final : public Task<HealthMonitor, 256> {
  public:
-  friend class Task<HealthMonitor, 512>;
+  friend class Task<HealthMonitor, 256>;
 
   [[noreturn]] void Run() noexcept override;
 

--- a/firmware/src/tasks/task_preprocessing.h
+++ b/firmware/src/tasks/task_preprocessing.h
@@ -26,9 +26,9 @@
 
 namespace task {
 
-class Preprocessing final : public Task<Preprocessing, 1024> {
+class Preprocessing final : public Task<Preprocessing, 512> {
  public:
-  friend class Task<Preprocessing, 1024>;
+  friend class Task<Preprocessing, 512>;
 
   [[noreturn]] void Run() noexcept override;
 

--- a/firmware/src/tasks/task_state_est.h
+++ b/firmware/src/tasks/task_state_est.h
@@ -29,9 +29,9 @@
 
 namespace task {
 
-class StateEstimation final : public Task<StateEstimation, 1024> {
+class StateEstimation final : public Task<StateEstimation, 512> {
  public:
-  friend class Task<StateEstimation, 1024>;
+  friend class Task<StateEstimation, 512>;
 
   [[noreturn]] void Run() noexcept override;
 


### PR DESCRIPTION
Other changes:
 - Extend FreeRTOS task name length to 32B,
 - Revert Preprocessing task's stack size to 512 words,
 - Add an example of stack usage monitoring in the Health Monitor task.