### PR TITLE
Tidy Compilation Warnings

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -51,7 +51,12 @@ link_directories(lib/CMSIS/DSP/lib)
 
 add_compile_options(-mcpu=cortex-m4 -mthumb -mthumb-interwork)
 add_compile_options(-ffunction-sections -fdata-sections -fno-common -fmessage-length=0 -fdiagnostics-color=always -fstack-usage
-        -Wall -Wimplicit-fallthrough -Wshadow -Wdouble-promotion -Wundef -Wformat=2 -Wformat-truncation=2 -Wformat-overflow -Werror=format)
+        -Wall -Wimplicit-fallthrough -Wshadow -Wdouble-promotion -Wundef -Wformat=2 -Wformat-truncation=2 -Wformat-overflow -Werror=format -Wformat-signedness)
+
+# Disable volatile warnings of type "compound assignment with 'volatile'-qualified left operand is deprecated [-Wvolatile]"
+# This is heavily used by STM libraries and creates too much noise when compiling
+# Eventually this flag should be set only for library files
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-volatile")
 
 # uncomment to mitigate c++17 absolute addresses warnings
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-register")

--- a/firmware/lib/STM/STM32F4/STM32F4xx/Include/stm32f4xx.h
+++ b/firmware/lib/STM/STM32F4/STM32F4xx/Include/stm32f4xx.h
@@ -8,8 +8,8 @@
   *          is using in the C source code, usually in main.c. This file contains:
   *           - Configuration section that allows to select:
   *              - The STM32F4xx device used in the target application
-  *              - To use or not the peripheral’s drivers in application code(i.e. 
-  *                code will be based on direct access to peripheral’s registers 
+  *              - To use or not the peripheral's drivers in application code(i.e.
+  *                code will be based on direct access to peripheral's registers
   *                rather than drivers API), this option is controlled by 
   *                "#define USE_HAL_DRIVER"
   *  
@@ -41,11 +41,16 @@
 #ifdef __cplusplus
  extern "C" {
 #endif /* __cplusplus */
-   
+
+/* Suppress warnings for non-existing define */
+#ifndef USBD_CLASS_BOS_ENABLED
+#define USBD_CLASS_BOS_ENABLED 0
+#endif
+
 /** @addtogroup Library_configuration_section
   * @{
   */
-  
+
 /**
   * @brief STM32 Family
   */

--- a/firmware/src/cli/cli_commands.cpp
+++ b/firmware/src/cli/cli_commands.cpp
@@ -575,7 +575,7 @@ static int32_t get_flight_idx(const char *log_idx_arg) {
   }
 
   char *endptr = nullptr;
-  int32_t flight_idx = strtol(log_idx_arg, &endptr, 10);
+  uint32_t flight_idx = strtoul(log_idx_arg, &endptr, 10);
 
   if (log_idx_arg == endptr) {
     cli_print_linef("\nInvalid argument: %s.", log_idx_arg);

--- a/firmware/src/config/cats_config.h
+++ b/firmware/src/config/cats_config.h
@@ -24,7 +24,7 @@
 
 /* The system will reload the default config when the number changes */
 /* Config version 2 / Minor 5 */
-#define CONFIG_VERSION 205
+#define CONFIG_VERSION 205U
 
 /* Number of supported recording speeds */
 #define NUM_REC_SPEEDS 10

--- a/firmware/src/flash/reader.cpp
+++ b/firmware/src/flash/reader.cpp
@@ -141,7 +141,7 @@ void parse_recording(uint16_t number, rec_entry_type_e filter_mask) {
           size_t elem_sz = sizeof(rec_elem.u.baro);
           lfs_file_read(&lfs, &curr_file, (uint8_t *)&rec_elem.u.imu, elem_sz);
           if ((rec_type_without_id & filter_mask) > 0) {
-            log_raw("%lu|BARO%hu|%lu|%lu", rec_elem.ts, get_id_from_record_type(rec_type), rec_elem.u.baro.pressure,
+            log_raw("%lu|BARO%hu|%ld|%ld", rec_elem.ts, get_id_from_record_type(rec_type), rec_elem.u.baro.pressure,
                     rec_elem.u.baro.temperature);
           }
         } break;
@@ -201,7 +201,7 @@ void parse_recording(uint16_t number, rec_entry_type_e filter_mask) {
           lfs_file_read(&lfs, &curr_file, (uint8_t *)&rec_elem.u.imu, elem_sz);
           if ((rec_type_without_id & filter_mask) > 0) {
             peripheral_act_t action = rec_elem.u.event_info.action;
-            log_raw("%lu|EVENT_INFO|%s|%s|%u", rec_elem.ts, event_map[rec_elem.u.event_info.event],
+            log_raw("%lu|EVENT_INFO|%s|%s|%d", rec_elem.ts, event_map[rec_elem.u.event_info.event],
                     action_map[rec_elem.u.event_info.action.action], action.action_arg);
           }
         } break;

--- a/firmware/src/main.h
+++ b/firmware/src/main.h
@@ -22,8 +22,3 @@
 
 /* Random pattern to tell system to jump to bootloader */
 #define BOOTLOADER_MAGIC_PATTERN 0xAA88BB77
-
-/* Suppress warnings for non-existing define */
-#ifndef USBD_CLASS_BOS_ENABLED
-#define USBD_CLASS_BOS_ENABLED 0
-#endif

--- a/firmware/src/tasks/task_peripherals.cpp
+++ b/firmware/src/tasks/task_peripherals.cpp
@@ -65,7 +65,7 @@ namespace task {
         /* get the actuator function */
         peripheral_act_fp curr_fp = action_table[action_list[i].action];
         if (curr_fp != nullptr) {
-          log_error("EXECUTING EVENT: %s, ACTION: %s, ACTION_ARG: %u", event_map[curr_event],
+          log_error("EXECUTING EVENT: %s, ACTION: %s, ACTION_ARG: %d", event_map[curr_event],
                     action_map[action_list[i].action], action_list[i].action_arg);
           /* call the actuator function */
           curr_fp(action_list[i].action_arg);


### PR DESCRIPTION
-  Add -Wformat-signedness flag and fix found issues
-  Disable -Wvolatile flag to reduce compilation noise
-  Define USBD_CLASS_BOS_ENABLED in stm32f4xx.h