### PR TITLE
Telemetry Improvements

### DIFF
--- a/firmware/src/tasks/task_health_monitor.h
+++ b/firmware/src/tasks/task_health_monitor.h
@@ -25,12 +25,20 @@ namespace task {
 
 class HealthMonitor final : public Task<HealthMonitor, 256> {
  public:
-  explicit HealthMonitor(const Buzzer& task_buzzer) : m_task_buzzer(task_buzzer) {}
+  explicit HealthMonitor(const Buzzer& task_buzzer) : m_task_buzzer(task_buzzer) { DeterminePyroCheck(); }
 
  private:
   [[noreturn]] void Run() noexcept override;
 
   const Buzzer& m_task_buzzer;
+
+  /**
+   * Determines if pyros should be checked for continuity by checking if there is an action that triggers them.
+   */
+  void DeterminePyroCheck();
+
+  bool m_check_pyro_1{false};
+  bool m_check_pyro_2{false};
 };
 
 }  // namespace task

--- a/firmware/src/tasks/task_recorder.cpp
+++ b/firmware/src/tasks/task_recorder.cpp
@@ -137,8 +137,14 @@ namespace task {
               break;
             }
           }
-          // TODO: Handle failed lfs_file_write
-          lfs_file_write(&lfs, &current_flight_file, rec_buffer, (lfs_size_t)REC_BUFFER_LEN);
+
+          const int32_t sz = lfs_file_write(&lfs, &current_flight_file, rec_buffer, (lfs_size_t)REC_BUFFER_LEN);
+
+          /* Writing less than REC_BUFFER_LEN bytes indicates that there is not enough space left on the flash chip. */
+          if ((sz > 0) && (static_cast<uint32_t>(sz) < static_cast<lfs_size_t>(REC_BUFFER_LEN))) {
+            add_error(CATS_ERR_LOG_FULL);
+          }
+
           ++sync_counter;
           /* Check for a new command */
           if ((sync_counter % 32) == 0) {

--- a/firmware/src/tasks/task_telemetry.cpp
+++ b/firmware/src/tasks/task_telemetry.cpp
@@ -21,7 +21,9 @@
 #include "comm/stream.h"
 #include "config/cats_config.h"
 #include "config/globals.h"
+#include "drivers/adc.h"
 #include "tasks/task_state_est.h"
+#include "util/battery.h"
 #include "util/crc.h"
 #include "util/gnss.h"
 #include "util/log.h"
@@ -50,11 +52,9 @@ enum state_e {
 #define INDEX_LEN      1
 #define TELE_MAX_POWER 30
 
-static float amplifier_temperature = 0.0F;
-
 void Telemetry::PackTxMessage(uint32_t ts, gnss_data_t* gnss, packed_tx_msg_t* tx_payload,
                               estimation_output_t estimation_data) const noexcept {
-  /* TODO add state, error, voltage and continuity information */
+  static_assert(sizeof(packed_tx_msg_t) == 15);
   if (m_fsm_enum == MOVING) {
     tx_payload->state = 0;
   } else if (m_fsm_enum == READY) {
@@ -70,11 +70,39 @@ void Telemetry::PackTxMessage(uint32_t ts, gnss_data_t* gnss, packed_tx_msg_t* t
   } else if (m_fsm_enum == TOUCHDOWN) {
     tx_payload->state = 6;
   }
+
   tx_payload->timestamp = ts / 100;
-  tx_payload->altitude = static_cast<int32_t>(estimation_data.height);
-  tx_payload->velocity = static_cast<int16_t>(estimation_data.velocity);
+
+  if (get_error_by_tag(CATS_ERR_NON_USER_CFG)) {
+    tx_payload->errors |= 0b00'00'01U;
+  }
+
+  if (get_error_by_tag(CATS_ERR_LOG_FULL)) {
+    tx_payload->errors |= 0b00'00'10U;
+  }
+
+  if (get_error_by_tag(CATS_ERR_FILTER_ACC) || get_error_by_tag(CATS_ERR_FILTER_HEIGHT)) {
+    tx_payload->errors |= 0b00'01'00U;
+  }
+
+  if (get_error_by_tag(CATS_ERR_TELEMETRY_HOT)) {
+    tx_payload->errors |= 0b00'10'00U;
+  }
+
   tx_payload->lat = static_cast<int32_t>(gnss->position.lat * 10000);
   tx_payload->lon = static_cast<int32_t>(gnss->position.lon * 10000);
+
+  tx_payload->altitude = static_cast<int32_t>(estimation_data.height);
+  tx_payload->velocity = static_cast<int16_t>(estimation_data.velocity);
+
+  tx_payload->voltage = battery_voltage_byte();
+
+  if (adc_get(ADC_PYRO1) > 500) {
+    tx_payload->pyro_continuity |= 0b01U;
+  }
+  if (adc_get(ADC_PYRO2) > 500) {
+    tx_payload->pyro_continuity |= 0b10U;
+  }
 }
 
 void Telemetry::ParseTxMessage(packed_tx_msg_t* rx_payload) const noexcept { log_info("Data Received."); }
@@ -108,8 +136,6 @@ void Telemetry::ParseTxMessage(packed_tx_msg_t* rx_payload) const noexcept { log
   gnss_data_t gnss_data = {};
   bool gnss_position_received = false;
 
-  packed_tx_msg_t tx_payload = {};
-
   uint32_t uart_timeout = osKernelGetTickCount();
 
   uint32_t tick_count = osKernelGetTickCount();
@@ -117,7 +143,7 @@ void Telemetry::ParseTxMessage(packed_tx_msg_t* rx_payload) const noexcept { log
   while (true) {
     /* Get new FSM enum */
     bool fsm_updated = GetNewFsmEnum();
-
+    packed_tx_msg_t tx_payload = {};
     PackTxMessage(tick_count, &gnss_data, &tx_payload, m_task_state_estimation.GetEstimationOutput());
     SendTxPayload((uint8_t*)&tx_payload, 16);
 
@@ -227,7 +253,7 @@ bool Telemetry::Parse(uint8_t op_code, const uint8_t* buffer, uint32_t length, g
   bool gnss_position_received = false;
 
   if (op_code == CMD_RX) {
-    packed_tx_msg_t rx_payload;
+    packed_tx_msg_t rx_payload{};
     memcpy(&rx_payload, buffer, length);
     ParseTxMessage(&rx_payload);
     // log_info("RX received");
@@ -246,7 +272,11 @@ bool Telemetry::Parse(uint8_t op_code, const uint8_t* buffer, uint32_t length, g
     gnss->time = (gnss_time_t){.hour = buffer[2], .min = buffer[1], .sec = buffer[0]};
     log_info("[GNSS time]: %02hu:%02hu:%02hu UTC", gnss->time.hour, gnss->time.min, gnss->time.sec);
   } else if (op_code == CMD_TEMP_INFO) {
-    memcpy(&amplifier_temperature, buffer, 4);
+    memcpy(const_cast<float32_t*>(&m_amplifier_temperature), buffer, 4);
+    if (m_amplifier_temperature > k_amplifier_hot_limit) {
+      add_error(CATS_ERR_TELEMETRY_HOT);
+    }
+    //    log_raw("Got temp %f", static_cast<double>(m_amplifier_temperature));
   } else {
     log_error("Unknown Op Code");
   }
@@ -285,7 +315,7 @@ void Telemetry::SendEnable() const noexcept {
 
 void Telemetry::SendDisable() const noexcept {
   uint8_t out[3];  // 1 OP + 1 LEN + 1 DATA + 1 CRC
-  out[0] = CMD_DISBALE;
+  out[0] = CMD_DISABLE;
   out[1] = 0;
   out[2] = crc8(out, 2);
 

--- a/firmware/src/tasks/task_telemetry.h
+++ b/firmware/src/tasks/task_telemetry.h
@@ -47,7 +47,7 @@ class Telemetry final : public Task<Telemetry, 1024> {
 
   void PackTxMessage(uint32_t ts, gnss_data_t* gnss, packed_tx_msg_t* tx_payload,
                      estimation_output_t estimation_data) const noexcept;
-  void ParseTxMessage(packed_tx_msg_t* rx_payload) const noexcept;
+  void ParseRxMessage(packed_tx_msg_t* rx_payload) const noexcept;
   bool Parse(uint8_t op_code, const uint8_t* buffer, uint32_t length, gnss_data_t* gnss) const noexcept;
   void SendLinkPhrase(uint8_t* phrase, uint32_t length) const noexcept;
   void SendSettings(uint8_t command, uint8_t value) const noexcept;

--- a/firmware/src/tasks/task_telemetry.h
+++ b/firmware/src/tasks/task_telemetry.h
@@ -32,19 +32,17 @@ class Telemetry final : public Task<Telemetry, 1024> {
 
   struct packed_tx_msg_t {
     uint8_t state : 3;
-    uint8_t errors : 4;
     uint16_t timestamp : 15;
+    uint8_t errors : 6;
     int32_t lat : 22;
     int32_t lon : 22;
     int32_t altitude : 17;
     int16_t velocity : 10;
     uint16_t voltage : 8;
-    uint16_t continuity : 3;
+    uint16_t pyro_continuity : 2;
     // fill up to 16 bytes
     uint8_t : 0;  // sent
     uint8_t d1;   // dummy
-    uint8_t d2;   // dummy
-    uint8_t d3;   // dummy
   } __attribute__((packed));
 
   void PackTxMessage(uint32_t ts, gnss_data_t* gnss, packed_tx_msg_t* tx_payload,
@@ -59,6 +57,10 @@ class Telemetry final : public Task<Telemetry, 1024> {
   [[nodiscard]] bool CheckValidOpCode(uint8_t op_code) const noexcept;
 
   const StateEstimation& m_task_state_estimation;
+
+  float32_t m_amplifier_temperature{0.0F};
+
+  static constexpr float32_t k_amplifier_hot_limit{60.F};
 };
 
 }  // namespace task

--- a/firmware/src/util/battery.cpp
+++ b/firmware/src/util/battery.cpp
@@ -64,6 +64,15 @@ float32_t battery_voltage() {
 /* Returns battery voltage as uint16, used for recording */
 uint16_t battery_voltage_short() { return static_cast<uint16_t>(round(battery_voltage() * 1000)); }
 
+/* Returns battery voltage as uint8, used for telemetry */
+uint8_t battery_voltage_byte() {
+  const float32_t voltage_f = round(battery_voltage() * 10);
+  if (voltage_f >= 255.0F) {
+    return 255U;
+  }
+  return static_cast<uint8_t>(voltage_f);
+}
+
 float32_t battery_cell_voltage() { return battery_voltage() / static_cast<float32_t>(cell_count); }
 
 battery_level_e battery_level() {

--- a/firmware/src/util/battery.h
+++ b/firmware/src/util/battery.h
@@ -26,5 +26,6 @@ void battery_monitor_init();
 
 float32_t battery_voltage();
 uint16_t battery_voltage_short();
+uint8_t battery_voltage_byte();
 
 battery_level_e battery_level();

--- a/firmware/src/util/error_handler.h
+++ b/firmware/src/util/error_handler.h
@@ -23,7 +23,7 @@
 // clang-format off
  enum cats_error_e: uint32_t {
   CATS_ERR_OK =             0,
-  CATS_ERR_NO_CONFIG =      1 << 0,   // 0x01
+  CATS_ERR_NON_USER_CFG =   1 << 0,   // 0x01
   CATS_ERR_NO_PYRO =        1 << 1,   // 0x02
   CATS_ERR_LOG_FULL =       1 << 2,   // 0x04
   CATS_ERR_BAT_LOW =        1 << 3,   // 0x08
@@ -39,7 +39,7 @@
   CATS_ERR_FILTER_ACC =     1 << 13,   // 0x2000
   CATS_ERR_FILTER_HEIGHT =  1 << 14,   // 0x4000
   CATS_ERR_HARD_FAULT =     1 << 15,   // 0x8000
-  CATS_ERR_NON_USER_CFG =   1 << 16,   // 0x10000
+  CATS_ERR_TELEMETRY_HOT =  1 << 16,   // 0x10000
 };
 // clang-format on
 

--- a/firmware/src/util/telemetry_reg.h
+++ b/firmware/src/util/telemetry_reg.h
@@ -37,7 +37,7 @@ enum transmission_mode_e {
 #define CMD_LINK_PHRASE 0x15
 
 #define CMD_ENABLE  0x20
-#define CMD_DISBALE 0x21
+#define CMD_DISABLE 0x21
 
 #define CMD_TX   0x30
 #define CMD_RX   0x31


### PR DESCRIPTION
 - Add "Telemetry Hot" error, emit it when warmer than 60 degrees Celsius.
 - Remove "No config" error (we have "Non-user config")
 - Add "Log full" error
 - Determine which pyros need to be checked in the Health Monitor task at bootup; check them in every iteration of the task
 - Add pyro continuity info to TX payload
 - Add 4 errors to TX payload
 - Add voltage info to TX payload

Closes #136 
Closes #137 
Closes #162 
Closes #217 
Closes #218 
Closes #255
