### PR TITLE
[FC] Enable printing stats & flights even when CATS_DEBUG flag is off

### DIFF
--- a/flight_computer/src/cli/cli.cpp
+++ b/flight_computer/src/cli/cli.cpp
@@ -31,7 +31,7 @@
 #include "util/log.h"
 
 #define CLI_IN_BUFFER_SIZE  128
-#define CLI_OUT_BUFFER_SIZE 256
+#define CLI_OUT_BUFFER_SIZE 420
 
 static uint32_t buffer_index = 0;
 


### PR DESCRIPTION
Other changes:
 - Expand the CLI print buffer to 420, to match the log print buffer,
 - Read out and print code version from flight log before parsing it.

Closes #316.