### PR TITLE
Fix large letters when entering link phrase setting

### DIFF
--- a/ground_station/src/hmi/window.cpp
+++ b/ground_station/src/hmi/window.cpp
@@ -1203,6 +1203,7 @@ void Window::initKeyboard(char *text, uint32_t maxLength) {
   }
   clearMainScreen();
 
+  display.setTextSize(1);
   updateKeyboardText(text, BLACK);
 
   display.setFont();


### PR DESCRIPTION
### Description
<!--- Describe what this pull request changes -->
This pull request sets the font size to one before displaying the link phrase setting.

### Checklist for changes
<!--- Fill out list with x when done or na when not applicable -->
- [x] Feature tested manually [Mandatory]
- [na] Simulation flight performed [Optional]
- [na] Drone flight performed [Optional]

### Related issues
Closes #349 