### PR TITLE
Update copyright notice year

### DIFF
--- a/flight_computer/CMakeLists.txt
+++ b/flight_computer/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+# Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/platformio.ini
+++ b/flight_computer/platformio.ini
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+# Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/pre_config.py
+++ b/flight_computer/pre_config.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+# Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/FreeRTOSConfig.h
+++ b/flight_computer/src/FreeRTOSConfig.h
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/cli/cli.cpp
+++ b/flight_computer/src/cli/cli.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/cli/cli.hpp
+++ b/flight_computer/src/cli/cli.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/cli/cli_commands.cpp
+++ b/flight_computer/src/cli/cli_commands.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/cli/cli_commands.hpp
+++ b/flight_computer/src/cli/cli_commands.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/cli/settings.cpp
+++ b/flight_computer/src/cli/settings.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/cli/settings.hpp
+++ b/flight_computer/src/cli/settings.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/comm/fifo.cpp
+++ b/flight_computer/src/comm/fifo.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/comm/fifo.hpp
+++ b/flight_computer/src/comm/fifo.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/comm/stream.cpp
+++ b/flight_computer/src/comm/stream.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/comm/stream.hpp
+++ b/flight_computer/src/comm/stream.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/comm/stream_group.cpp
+++ b/flight_computer/src/comm/stream_group.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/comm/stream_group.hpp
+++ b/flight_computer/src/comm/stream_group.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/config/cats_config.cpp
+++ b/flight_computer/src/config/cats_config.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/config/cats_config.hpp
+++ b/flight_computer/src/config/cats_config.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/config/control_config.hpp
+++ b/flight_computer/src/config/control_config.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/config/globals.cpp
+++ b/flight_computer/src/config/globals.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/config/globals.hpp
+++ b/flight_computer/src/config/globals.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/control/calibration.cpp
+++ b/flight_computer/src/control/calibration.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/control/calibration.hpp
+++ b/flight_computer/src/control/calibration.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/control/data_processing.cpp
+++ b/flight_computer/src/control/data_processing.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/control/data_processing.hpp
+++ b/flight_computer/src/control/data_processing.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/control/flight_phases.cpp
+++ b/flight_computer/src/control/flight_phases.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/control/flight_phases.hpp
+++ b/flight_computer/src/control/flight_phases.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/control/kalman_filter.cpp
+++ b/flight_computer/src/control/kalman_filter.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/control/kalman_filter.hpp
+++ b/flight_computer/src/control/kalman_filter.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/control/orientation_filter.cpp
+++ b/flight_computer/src/control/orientation_filter.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/control/orientation_filter.hpp
+++ b/flight_computer/src/control/orientation_filter.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/drivers/adc.cpp
+++ b/flight_computer/src/drivers/adc.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/drivers/adc.hpp
+++ b/flight_computer/src/drivers/adc.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/drivers/buzzer.cpp
+++ b/flight_computer/src/drivers/buzzer.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/drivers/buzzer.hpp
+++ b/flight_computer/src/drivers/buzzer.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/drivers/gpio.hpp
+++ b/flight_computer/src/drivers/gpio.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/drivers/pwm.cpp
+++ b/flight_computer/src/drivers/pwm.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/drivers/pwm.hpp
+++ b/flight_computer/src/drivers/pwm.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/drivers/servo.cpp
+++ b/flight_computer/src/drivers/servo.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/drivers/servo.hpp
+++ b/flight_computer/src/drivers/servo.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/drivers/spi.hpp
+++ b/flight_computer/src/drivers/spi.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/drivers/uart.cpp
+++ b/flight_computer/src/drivers/uart.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/drivers/uart.hpp
+++ b/flight_computer/src/drivers/uart.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/drivers/w25q.cpp
+++ b/flight_computer/src/drivers/w25q.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/drivers/w25q.hpp
+++ b/flight_computer/src/drivers/w25q.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/flash/lfs_custom.cpp
+++ b/flight_computer/src/flash/lfs_custom.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/flash/lfs_custom.hpp
+++ b/flight_computer/src/flash/lfs_custom.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/flash/reader.cpp
+++ b/flight_computer/src/flash/reader.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/flash/reader.hpp
+++ b/flight_computer/src/flash/reader.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/flash/recorder.cpp
+++ b/flight_computer/src/flash/recorder.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/flash/recorder.hpp
+++ b/flight_computer/src/flash/recorder.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/init/config.cpp
+++ b/flight_computer/src/init/config.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/init/config.hpp
+++ b/flight_computer/src/init/config.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/init/system.cpp
+++ b/flight_computer/src/init/system.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/init/system.hpp
+++ b/flight_computer/src/init/system.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/main.cpp
+++ b/flight_computer/src/main.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/main.hpp
+++ b/flight_computer/src/main.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/sensors/lsm6dso32.hpp
+++ b/flight_computer/src/sensors/lsm6dso32.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/sensors/ms5607.hpp
+++ b/flight_computer/src/sensors/ms5607.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/syscalls.c
+++ b/flight_computer/src/syscalls.c
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/sysmem.c
+++ b/flight_computer/src/sysmem.c
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/target/VEGA/STM32F411CCUX_FLASH.ld
+++ b/flight_computer/src/target/VEGA/STM32F411CCUX_FLASH.ld
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/* Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  *

--- a/flight_computer/src/target/VEGA/STM32F411CCUX_RAM.ld
+++ b/flight_computer/src/target/VEGA/STM32F411CCUX_RAM.ld
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/* Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  *

--- a/flight_computer/src/target/VEGA/startup_stm32f411ccux.S
+++ b/flight_computer/src/target/VEGA/startup_stm32f411ccux.S
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/* Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  *

--- a/flight_computer/src/target/VEGA/stm32f4xx_hal_conf.h
+++ b/flight_computer/src/target/VEGA/stm32f4xx_hal_conf.h
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/target/VEGA/stm32f4xx_hal_msp.cpp
+++ b/flight_computer/src/target/VEGA/stm32f4xx_hal_msp.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/target/VEGA/stm32f4xx_hal_timebase_tim.cpp
+++ b/flight_computer/src/target/VEGA/stm32f4xx_hal_timebase_tim.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/target/VEGA/stm32f4xx_it.cpp
+++ b/flight_computer/src/target/VEGA/stm32f4xx_it.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/target/VEGA/stm32f4xx_it.h
+++ b/flight_computer/src/target/VEGA/stm32f4xx_it.h
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/target/VEGA/system_stm32f4xx.cpp
+++ b/flight_computer/src/target/VEGA/system_stm32f4xx.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/target/VEGA/target.cpp
+++ b/flight_computer/src/target/VEGA/target.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/target/VEGA/target.hpp
+++ b/flight_computer/src/target/VEGA/target.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task.hpp
+++ b/flight_computer/src/tasks/task.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_buzzer.cpp
+++ b/flight_computer/src/tasks/task_buzzer.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_buzzer.hpp
+++ b/flight_computer/src/tasks/task_buzzer.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_cdc.cpp
+++ b/flight_computer/src/tasks/task_cdc.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_cdc.hpp
+++ b/flight_computer/src/tasks/task_cdc.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_cli.cpp
+++ b/flight_computer/src/tasks/task_cli.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_cli.hpp
+++ b/flight_computer/src/tasks/task_cli.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_flight_fsm.cpp
+++ b/flight_computer/src/tasks/task_flight_fsm.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_flight_fsm.hpp
+++ b/flight_computer/src/tasks/task_flight_fsm.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_health_monitor.cpp
+++ b/flight_computer/src/tasks/task_health_monitor.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_health_monitor.hpp
+++ b/flight_computer/src/tasks/task_health_monitor.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_peripherals.cpp
+++ b/flight_computer/src/tasks/task_peripherals.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_peripherals.hpp
+++ b/flight_computer/src/tasks/task_peripherals.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_preprocessing.cpp
+++ b/flight_computer/src/tasks/task_preprocessing.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_preprocessing.hpp
+++ b/flight_computer/src/tasks/task_preprocessing.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_recorder.cpp
+++ b/flight_computer/src/tasks/task_recorder.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_recorder.hpp
+++ b/flight_computer/src/tasks/task_recorder.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_sensor_read.cpp
+++ b/flight_computer/src/tasks/task_sensor_read.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_sensor_read.hpp
+++ b/flight_computer/src/tasks/task_sensor_read.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_simulator.cpp
+++ b/flight_computer/src/tasks/task_simulator.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_simulator.hpp
+++ b/flight_computer/src/tasks/task_simulator.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_state_est.cpp
+++ b/flight_computer/src/tasks/task_state_est.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_state_est.hpp
+++ b/flight_computer/src/tasks/task_state_est.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_telemetry.cpp
+++ b/flight_computer/src/tasks/task_telemetry.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_telemetry.hpp
+++ b/flight_computer/src/tasks/task_telemetry.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_usb_device.cpp
+++ b/flight_computer/src/tasks/task_usb_device.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/tasks/task_usb_device.hpp
+++ b/flight_computer/src/tasks/task_usb_device.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/usb/msc/emfat.c
+++ b/flight_computer/src/usb/msc/emfat.c
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/usb/msc/emfat.h
+++ b/flight_computer/src/usb/msc/emfat.h
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/usb/msc/emfat_file.cpp
+++ b/flight_computer/src/usb/msc/emfat_file.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/usb/msc/emfat_file.h
+++ b/flight_computer/src/usb/msc/emfat_file.h
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/usb/msc_disk.c
+++ b/flight_computer/src/usb/msc_disk.c
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/usb/tusb_config.h
+++ b/flight_computer/src/usb/tusb_config.h
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/usb/usb_descriptors.c
+++ b/flight_computer/src/usb/usb_descriptors.c
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/flight_computer/src/util/actions.cpp
+++ b/flight_computer/src/util/actions.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/util/actions.hpp
+++ b/flight_computer/src/util/actions.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/util/battery.cpp
+++ b/flight_computer/src/util/battery.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/util/battery.hpp
+++ b/flight_computer/src/util/battery.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/util/crc.cpp
+++ b/flight_computer/src/util/crc.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/util/crc.hpp
+++ b/flight_computer/src/util/crc.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/util/debug.cpp
+++ b/flight_computer/src/util/debug.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/util/enum_str_maps.cpp
+++ b/flight_computer/src/util/enum_str_maps.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/util/enum_str_maps.hpp
+++ b/flight_computer/src/util/enum_str_maps.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/util/error_handler.cpp
+++ b/flight_computer/src/util/error_handler.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/util/error_handler.hpp
+++ b/flight_computer/src/util/error_handler.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/util/gnss.hpp
+++ b/flight_computer/src/util/gnss.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/util/log.cpp
+++ b/flight_computer/src/util/log.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/util/log.h
+++ b/flight_computer/src/util/log.h
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/util/math_util.cpp
+++ b/flight_computer/src/util/math_util.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/util/math_util.hpp
+++ b/flight_computer/src/util/math_util.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/util/task_util.cpp
+++ b/flight_computer/src/util/task_util.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/util/task_util.hpp
+++ b/flight_computer/src/util/task_util.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/util/telemetry_reg.hpp
+++ b/flight_computer/src/util/telemetry_reg.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/flight_computer/src/util/types.hpp
+++ b/flight_computer/src/util/types.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/dfu_reboot.py
+++ b/ground_station/dfu_reboot.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+# Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/ground_station/lib/QMC5883Compass/src/QMC5883Compass.cpp
+++ b/ground_station/lib/QMC5883Compass/src/QMC5883Compass.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2025 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/lib/QMC5883Compass/src/QMC5883Compass.hpp
+++ b/ground_station/lib/QMC5883Compass/src/QMC5883Compass.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2025 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/lib/QMC5883Compass/src/QMC5883PCompass.cpp
+++ b/ground_station/lib/QMC5883Compass/src/QMC5883PCompass.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2025 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/lib/QMC5883Compass/src/QMC5883PCompass.hpp
+++ b/ground_station/lib/QMC5883Compass/src/QMC5883PCompass.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2025 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/packet_installer.py
+++ b/ground_station/packet_installer.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+# Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/ground_station/platformio.ini
+++ b/ground_station/platformio.ini
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+# Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/post_config.py
+++ b/ground_station/post_config.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+# Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/pre_config.py
+++ b/ground_station/pre_config.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+# Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/serial_console.py
+++ b/ground_station/serial_console.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+# Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/ground_station/serial_terminal.py
+++ b/ground_station/serial_terminal.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+# Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/ground_station/src/USB.cpp
+++ b/ground_station/src/USB.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/ground_station/src/config.cpp
+++ b/ground_station/src/config.cpp
@@ -1,5 +1,5 @@
 
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/config.hpp
+++ b/ground_station/src/config.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/console.cpp
+++ b/ground_station/src/console.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/ground_station/src/console.hpp
+++ b/ground_station/src/console.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/ground_station/src/hmi/bmp.hpp
+++ b/ground_station/src/hmi/bmp.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/hmi/hmi.cpp
+++ b/ground_station/src/hmi/hmi.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/hmi/hmi.hpp
+++ b/ground_station/src/hmi/hmi.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/hmi/settings.cpp
+++ b/ground_station/src/hmi/settings.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/hmi/settings.hpp
+++ b/ground_station/src/hmi/settings.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/hmi/window.cpp
+++ b/ground_station/src/hmi/window.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/hmi/window.hpp
+++ b/ground_station/src/hmi/window.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/logging/recorder.cpp
+++ b/ground_station/src/logging/recorder.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/logging/recorder.hpp
+++ b/ground_station/src/logging/recorder.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/main.cpp
+++ b/ground_station/src/main.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/navigation.cpp
+++ b/ground_station/src/navigation.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/navigation.hpp
+++ b/ground_station/src/navigation.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/systemParser.cpp
+++ b/ground_station/src/systemParser.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/systemParser.hpp
+++ b/ground_station/src/systemParser.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/telemetry/crc.cpp
+++ b/ground_station/src/telemetry/crc.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/telemetry/crc.hpp
+++ b/ground_station/src/telemetry/crc.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/telemetry/parser.cpp
+++ b/ground_station/src/telemetry/parser.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/telemetry/parser.hpp
+++ b/ground_station/src/telemetry/parser.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/telemetry/telemetry.cpp
+++ b/ground_station/src/telemetry/telemetry.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/telemetry/telemetry.hpp
+++ b/ground_station/src/telemetry/telemetry.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/telemetry/telemetryData.hpp
+++ b/ground_station/src/telemetry/telemetryData.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/telemetry/telemetry_reg.hpp
+++ b/ground_station/src/telemetry/telemetry_reg.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ground_station/src/utils.cpp
+++ b/ground_station/src/utils.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/ground_station/src/utils.hpp
+++ b/ground_station/src/utils.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/ground_station/uf2_loader.py
+++ b/ground_station/uf2_loader.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+# Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/ground_station/upload_script.py
+++ b/ground_station/upload_script.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+# Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/telemetry/lib/Crc/Crc.cpp
+++ b/telemetry/lib/Crc/Crc.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/lib/Crc/Crc.hpp
+++ b/telemetry/lib/Crc/Crc.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/lib/LqCalculator/LqCalculator.hpp
+++ b/telemetry/lib/LqCalculator/LqCalculator.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/lib/Random/Random.cpp
+++ b/telemetry/lib/Random/Random.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/lib/Random/Random.hpp
+++ b/telemetry/lib/Random/Random.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/lib/Thermistor/Thermistor.hpp
+++ b/telemetry/lib/Thermistor/Thermistor.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/platformio.ini
+++ b/telemetry/platformio.ini
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+# Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/pre_config.py
+++ b/telemetry/pre_config.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+# Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/src/Common.cpp
+++ b/telemetry/src/Common.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/src/Common.hpp
+++ b/telemetry/src/Common.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/src/Fhss/Fhss.cpp
+++ b/telemetry/src/Fhss/Fhss.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/src/Fhss/Fhss.hpp
+++ b/telemetry/src/Fhss/Fhss.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/src/Gps/Gps.cpp
+++ b/telemetry/src/Gps/Gps.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/src/Gps/Gps.hpp
+++ b/telemetry/src/Gps/Gps.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/src/Main.cpp
+++ b/telemetry/src/Main.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/src/Main.hpp
+++ b/telemetry/src/Main.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/src/SerialComm/Parser.cpp
+++ b/telemetry/src/SerialComm/Parser.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/src/SerialComm/Parser.hpp
+++ b/telemetry/src/SerialComm/Parser.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/src/SerialComm/Serial.hpp
+++ b/telemetry/src/SerialComm/Serial.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/src/Telemetry_reg.h
+++ b/telemetry/src/Telemetry_reg.h
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/src/Transmission/Transmission.cpp
+++ b/telemetry/src/Transmission/Transmission.cpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/src/Transmission/Transmission.hpp
+++ b/telemetry/src/Transmission/Transmission.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/src/Transmission/TransmissionSettings.hpp
+++ b/telemetry/src/Transmission/TransmissionSettings.hpp
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/telemetry/src/st/stm32g0xx_hal_conf.h
+++ b/telemetry/src/st/stm32g0xx_hal_conf.h
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/telemetry/src/st/stm32g0xx_hal_msp.c
+++ b/telemetry/src/st/stm32g0xx_hal_msp.c
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/telemetry/src/st/stm32g0xx_it.c
+++ b/telemetry/src/st/stm32g0xx_it.c
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/telemetry/src/st/stm32g0xx_it.h
+++ b/telemetry/src/st/stm32g0xx_it.h
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/telemetry/src/st/syscalls.c
+++ b/telemetry/src/st/syscalls.c
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/telemetry/src/st/sysmem.c
+++ b/telemetry/src/st/sysmem.c
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///

--- a/telemetry/src/st/system_stm32g0xx.c
+++ b/telemetry/src/st/system_stm32g0xx.c
@@ -1,4 +1,4 @@
-/// Copyright (C) 2020, 2024 Control and Telemetry Systems GmbH
+/// Copyright (C) 2020, 2026 Control and Telemetry Systems GmbH
 ///
 /// SPDX-License-Identifier: GPL-3.0-or-later
 ///


### PR DESCRIPTION
This patch updates the copyright notice year to 2026.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refreshes legal headers to 2026 across the repository.
> 
> - Updates copyright notices in source/header files, scripts, and build configs for `flight_computer`, `ground_station`, and `telemetry`
> - No functional or behavioral changes; code remains identical
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbb68c4dcbf26c077b5a4a5873d4ab16e9a26d8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->