### PR TITLE
[GS] Support alternate IMU ID and libusb fallback

### DIFF
--- a/ground_station/dfu_reboot.py
+++ b/ground_station/dfu_reboot.py
@@ -19,9 +19,22 @@ import usb.core
 import usb.backend.libusb1
 
 
+def get_libusb_backend():
+    backend = usb.backend.libusb1.get_backend()
+    if backend is not None:
+        return backend
+
+    try:
+        from libusb._platform import DLL_PATH
+    except (ImportError, OSError):
+        return None
+
+    return usb.backend.libusb1.get_backend(find_library=lambda _name: str(DLL_PATH))
+
+
 class DFU_Reboot:
     def __init__(self):
-        self.backend = usb.backend.libusb1.get_backend()
+        self.backend = get_libusb_backend()
         if self.backend is None:
             print("Warning: libusb backend not found; falling back to PyUSB default")
             self.backend = None

--- a/ground_station/lib/LSM6DS3/src/LSM6DS3.cpp
+++ b/ground_station/lib/LSM6DS3/src/LSM6DS3.cpp
@@ -54,7 +54,8 @@ int LSM6DS3Class::begin(TwoWire& wire, uint8_t slaveAddress)
     //_wire->begin(14,15);
   }*/
 
-  if (readRegister(LSM6DS3_WHO_AM_I_REG) != 0x6B) {
+  int whoAmI = readRegister(LSM6DS3_WHO_AM_I_REG);
+  if (whoAmI != 0x69 && whoAmI != 0x6B) {
     end();
     return 0;
   }
@@ -84,7 +85,6 @@ void LSM6DS3Class::end()
   } else {
     writeRegister(LSM6DS3_CTRL2_G, 0x00);
     writeRegister(LSM6DS3_CTRL1_XL, 0x00);
-    _wire->end();
   }
 }
 

--- a/ground_station/platformio.ini
+++ b/ground_station/platformio.ini
@@ -37,7 +37,7 @@ lib_deps =
 
 build_flags =
   -DCFG_TUSB_CONFIG_FILE='"sdkconfig.h"' ; Use default TinyUSB configuration
-  -DFIRMWARE_VERSION='"1.1.4"'           ; Enter Firmware Version here
+  -DFIRMWARE_VERSION='"1.1.5"'           ; Enter Firmware Version here
   -DUSB_MANUFACTURER='"CATS"'            ; USB Manufacturer string
   -DUSB_PRODUCT='"CATS Ground Station"'   ; USB Product String
   -D USB_SERIAL="0"                      ; Enter Device Serial Number here


### PR DESCRIPTION
## Summary
- accept either `0x69` or `0x6B` from `LSM6DS3` during initialization
- avoid ending the shared I2C bus in `LSM6DS3::end()` so that magnetometer initialization can still proceed in case of an IMU error
- add a libusb backend fallback path for DFU reboot on platforms that package the DLL differently

## Testing
- Not run (not requested)